### PR TITLE
Post issues to inactive tracks

### DIFF
--- a/main.go
+++ b/main.go
@@ -115,12 +115,17 @@ func main() {
 	}
 
 	for _, track := range pld.Tracks {
-		if !track.Active || !track.has(*exercise) {
+		if !track.has(*exercise) {
 			continue
 		}
 
 		if !*yes {
-			fmt.Printf("- %s\n", track.ID)
+			var status string
+			if !track.Active {
+				status = " (inactive)"
+			}
+
+			fmt.Printf("- %s%s\n", track.ID, status)
 			continue
 		}
 


### PR DESCRIPTION
If a track that has not yet been activated has implemented an exercise
then the issue is relevant.

If the issue is not specific to an exercise (such as documentation
across the board), then it is also relevant to inactive tracks; perhaps
even more so, since tracks often languish in an unstarted/inactive state
for a long time before someone decides to port enough exercises to make
it live, and the starter repository will have lots of old references in
it.

@petertseng What do you think?
