### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,25 @@ If not, grab the [most recent release](https://github.com/kytrinyx/blazon/releas
 
 Create a personal api token, **giving it the scope "public_repo"**.
 Save it to an environment variable named `BLAZON_GITHUB_API_TOKEN`.
+
+## Usage
+
+Run `blazon` to see the available flags.
+
+## Tips
+
+Before submitting the blazon issue, make sure that there is an issue that
+summarizes the problem/solution. If it doesn't already exist, then create one
+(it might fit into the https://github.com/exercism/x-common repository, or the
+https://github.com/exercism/todo repository).
+
+Then include a link to the summary issue in the body of the text for the
+blazon issue.
+
+This will ensure that the summary issue contains references to each of the
+individual issues in each of the track repositories. Each of these links will
+include an icon whose color indicates the status of the issue (open|closed).
+
+This ensures that there is a handy, visible "todo" list that immediately shows
+the overall status of the effort, and once all of the related links are red,
+the summary issue can be closed.


### PR DESCRIPTION
I realized today (https://github.com/exercism/todo/issues/181) that I could have made things easier and clearer if I had included the link to the top-level issue in the body of the issue, instead of posting the list of issues manually.
